### PR TITLE
Added back old method removed

### DIFF
--- a/lib/pagarme/model.rb
+++ b/lib/pagarme/model.rb
@@ -36,6 +36,7 @@ module PagarMe
           count: count
         )).call
       end
+      alias :find_by_hash :find_by
 
       def all(page = 1, count = 10)
         find_by Hash.new, page, count


### PR DESCRIPTION
Now find_by_hash has an alias find_by that is more idiomatic and not ambiguous