### PR TITLE
Added IdMustBeInformedError instead of 'Invalid ID'

### DIFF
--- a/lib/pagarme/errors.rb
+++ b/lib/pagarme/errors.rb
@@ -14,6 +14,12 @@ module PagarMe
   class RequestError < PagarMeError
   end
 
+  class IdMustBeInformedError < RequestError
+    def initialize
+      super 'ID must be informed'
+    end
+  end
+
   class ResponseError < PagarMeError
     attr_reader :request_params, :error
 

--- a/lib/pagarme/model.rb
+++ b/lib/pagarme/model.rb
@@ -1,6 +1,5 @@
 module PagarMe
   class Model < PagarMeObject
-
     def create
       update PagarMe::Request.post(self.class.url, params: to_hash).run
       self
@@ -12,7 +11,7 @@ module PagarMe
     end
 
     def url(*params)
-      raise RequestError.new('Invalid ID') unless id.present?
+      raise IdMustBeInformedError.new unless id.present?
       self.class.url CGI.escape(id.to_s), *params
     end
 
@@ -23,7 +22,7 @@ module PagarMe
       end
 
       def find_by_id(id)
-        raise RequestError.new('Invalid ID') unless id.present?
+        raise IdMustBeInformedError.new unless id.present?
         PagarMe::Request.get(url id).call
       end
       alias :find :find_by_id

--- a/lib/pagarme/nested_model.rb
+++ b/lib/pagarme/nested_model.rb
@@ -1,5 +1,7 @@
 module PagarMe
   class NestedModel < Model
+    PARENT_ID_MUST_BE_INFORMED = 'Parent ID must be informed'.freeze
+
     attr_accessor :parent_id
 
     def initialize(hash = Hash.new)
@@ -14,7 +16,7 @@ module PagarMe
     end
 
     def url(*params)
-      raise RequestError.new('Invalid ID') unless id.present?
+      raise IdMustBeInformedError.new unless id.present?
       self.class.url parent_id, CGI.escape(id.to_s), *params
     end
 
@@ -25,8 +27,8 @@ module PagarMe
       end
 
       def find_by_id(parent_id, id)
-        raise RequestError.new('Invalid ID')        unless        id.present?
-        raise RequestError.new('Invalid parent ID') unless parent_id.present?
+        raise IdMustBeInformedError.new                    unless        id.present?
+        raise RequestError.new(PARENT_ID_MUST_BE_INFORMED) unless parent_id.present?
 
         object = PagarMe::Request.get(url parent_id, id).call
         if object
@@ -53,7 +55,7 @@ module PagarMe
       end
 
       def url(parent_id, *params)
-        raise RequestError.new('Invalid parent ID') unless parent_id.present?
+        raise RequestError.new(PARENT_ID_MUST_BE_INFORMED) unless parent_id.present?
         ["/#{parent_resource_name}", parent_id, "#{ CGI.escape underscored_class_name }s", *params].join '/'
       end
 

--- a/lib/pagarme/resources/balance.rb
+++ b/lib/pagarme/resources/balance.rb
@@ -15,7 +15,7 @@ module PagarMe
       end
 
       def find_by_recipient_id(recipient_id = nil)
-        raise RequestError.new('Invalid ID') unless recipient_id.present?
+        raise IdMustBeInformed.new unless recipient_id.present?
         PagarMe::Request.get(url recipient_id).call
       end
     end

--- a/lib/pagarme/resources/balance_operation.rb
+++ b/lib/pagarme/resources/balance_operation.rb
@@ -28,7 +28,7 @@ module PagarMe
       def find_by_recipient_id(recipient_id, *args, **params)
         params = PagarMe::Model.extract_page_count_or_params(*args, **params)
         raise RequestError.new('Invalid page count') if params[:page] < 1 or params[:count] < 1
-        raise RequestError.new('Invalid ID')         unless recipient_id.present?
+        raise IdMustBeInformed.new                   unless recipient_id.present?
 
         PagarMe::Request.get(url(recipient_id), params: params).call
       end

--- a/test/pagarme/resources/subscription_test.rb
+++ b/test/pagarme/resources/subscription_test.rb
@@ -67,11 +67,11 @@ module PagarMe
     end
 
     should 'raise an error when nil or empty string as ID' do
-      assert_raises RequestError do
+      assert_raises IdMustBeInformedError do
         PagarMe::Subscription.find_by_id nil
       end
 
-      assert_raises RequestError do
+      assert_raises IdMustBeInformedError do
         PagarMe::Subscription.find_by_id ''
       end
     end

--- a/test/pagarme/resources/transaction_test.rb
+++ b/test/pagarme/resources/transaction_test.rb
@@ -79,11 +79,11 @@ module PagarMe
     end
 
     should 'raise an error when nil or empty string as ID' do
-      assert_raises RequestError do
+      assert_raises IdMustBeInformedError do
         PagarMe::Transaction.find_by_id nil
       end
 
-      assert_raises RequestError do
+      assert_raises IdMustBeInformedError do
         PagarMe::Transaction.find_by_id ''
       end
     end


### PR DESCRIPTION
With this new error, it's more clearly what 'Invalid ID' means and avoid
or decrease the search through the gem's code.