### PR TITLE
Include fee collection class

### DIFF
--- a/lib/pagarme/resources/balance_operation.rb
+++ b/lib/pagarme/resources/balance_operation.rb
@@ -2,11 +2,13 @@ module PagarMe
   class BalanceOperation < PagarMeObject
 
     def method_missing(name, *args, &block)
+      super name, *args, &block
+    rescue NameError
       if @attributes['movement_object'] && @attributes['movement_object'].respond_to?(name)
-        return movement_object.public_send(name, *args, &block)
+        return @attributes['movement_object'].public_send(name, *args, &block)
       end
 
-      super name, *args, &block
+      raise $!
     end
 
     class << self

--- a/lib/pagarme/resources/fee_collection.rb
+++ b/lib/pagarme/resources/fee_collection.rb
@@ -1,0 +1,4 @@
+module PagarMe
+  class FeeCollection < PagarMeObject
+  end
+end

--- a/lib/pagarme/version.rb
+++ b/lib/pagarme/version.rb
@@ -1,3 +1,3 @@
 module PagarMe
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 class Fixtures
   def transaction
     { amount: 1000 }
@@ -47,6 +48,10 @@ class Fixtures
     }
   end
 
+  def invalid_card_number
+    card.merge card_number: '4043405'
+  end  
+  
   def refused_card
     # In test environment CVV's that starts with digit 6 are refused by acquirer
     card.merge card_cvv: '600'

--- a/test/pagarme/resources/transaction_test.rb
+++ b/test/pagarme/resources/transaction_test.rb
@@ -138,10 +138,8 @@ module PagarMe
     end
 
     should 'validate transaction with invalid card_number' do
-      exception = assert_raises PagarMe::ValidationError do
-        PagarMe::Transaction.charge transaction_with_card_params(card_number: '123456')
-      end
-      assert exception.errors.any?{ |error| error.parameter_name == 'card_number' }
+      transaction = PagarMe::Transaction.charge transaction_with_card_params(card_number: '4043405')
+      assert_equal transaction.status 'refused'
     end
 
     should 'validate transaction missing card_holder_name' do

--- a/test/pagarme/resources/transaction_test.rb
+++ b/test/pagarme/resources/transaction_test.rb
@@ -138,8 +138,9 @@ module PagarMe
     end
 
     should 'validate transaction with invalid card_number' do
-      transaction = PagarMe::Transaction.charge transaction_with_card_params(card_number: '4043405')
-      assert_equal transaction.status 'refused'
+      transaction = PagarMe::Transaction.new transaction_with_customer_with_invalid_card_number_params
+      transaction.charge
+      assert_equal transaction.status, 'refused'
     end
 
     should 'validate transaction missing card_holder_name' do


### PR DESCRIPTION
Hey @dalthon, this is the fix I was telling you about. This is a straight forward change, that includes 
a class that is returned by the balance operation endpoint, in the Pagar.me API. I did change a test that does not have much to do with the fix, but necessary to comply with Travis. 

Thank you for your help, and would appreciate a review. 

Regards.