### PR TITLE
Fix Postback Test

### DIFF
--- a/test/pagarme/resources/postback_test.rb
+++ b/test/pagarme/resources/postback_test.rb
@@ -9,7 +9,7 @@ module PagarMe
       end
     end
 
-    should 'be valid when has invalid signature' do
+    should 'not be valid when has invalid signature' do
       postback = PagarMe::Postback.new postback_response_params(signature: 'sha1=invalid signature')
       assert !postback.valid?
     end

--- a/test/pagarme/resources/postback_test.rb
+++ b/test/pagarme/resources/postback_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../test_helper'
 
 module PagarMe
-  class TransactionTest < PagarMeTestCase
+  class PostbackTest < PagarMeTestCase
     should 'be valid when has valid signature' do
       fixed_api_key do
         postback = PagarMe::Postback.new postback_response_params


### PR DESCRIPTION
This PR fixes Postback Test:

- Class name was 'TransactionTest' instead of 'PostbackTest'
- Test description was setting the inverse expectation
