### PR TITLE
force tls 1.2

### DIFF
--- a/lib/pagarme/request.rb
+++ b/lib/pagarme/request.rb
@@ -85,7 +85,8 @@ module PagarMe
         open_timeout: PagarMe.open_timeout,
         timeout:      PagarMe.timeout,
         ssl_ca_file:  SSL_CA_FILEPATH,
-        headers:      DEFAULT_HEADERS.merge(headers)
+        headers:      DEFAULT_HEADERS.merge(headers),
+        ssl_version:  'TLSv1_2'
       }
     end
 


### PR DESCRIPTION
Fala @dalthon , pode revisar?

Esse PR força o uso do TLS 1.2 nas requisições para o Pagar.me

Se tiver qualquer dúvida fico à disposição