### PR TITLE
fix: Removes calls to confirm and delete bulk anticipation endpoints

### DIFF
--- a/lib/pagarme/resources/bulk_anticipation.rb
+++ b/lib/pagarme/resources/bulk_anticipation.rb
@@ -1,14 +1,5 @@
 module PagarMe
   class BulkAnticipation < NestedModel
-    def confirm
-      update self.class.confirm(parent_id, id).attributes
-      self
-    end
-
-    def delete
-      self.class.delete parent_id, id
-    end
-
     def cancel
       update self.class.cancel(parent_id, id).attributes
       self
@@ -17,14 +8,6 @@ module PagarMe
     class << self
       def parent_resource_name
         'recipients'
-      end
-
-      def confirm(recipient_id, id)
-        PagarMe::Request.post( url(recipient_id, id, 'confirm') ).call
-      end
-
-      def delete(recipient_id, id)
-        PagarMe::Request.delete( url(recipient_id, id) ).call
       end
 
       def cancel(recipient_id, id)

--- a/test/pagarme/resources/bulk_anticipation_test.rb
+++ b/test/pagarme/resources/bulk_anticipation_test.rb
@@ -32,33 +32,6 @@ module PagarMe
       assert recipient.bulk_anticipations.count > 0
     end
 
-    should 'create a building anticipation an later confirm it' do
-      recipient    = PagarMe::Recipient.default
-      anticipation = recipient.bulk_anticipate anticipation_params(build: true)
-      assert_equal anticipation.id, BulkAnticipation.confirm(recipient.id, anticipation.id).id
-
-      anticipation = recipient.bulk_anticipate anticipation_params(build: true)
-      assert_equal anticipation.id, anticipation.confirm.id
-    end
-
-    should 'create a building anticipation and later delete it' do
-      recipient    = PagarMe::Recipient.default
-      anticipation = recipient.bulk_anticipate anticipation_params(build: true)
-
-      assert_equal anticipation.id, PagarMe::BulkAnticipation.find(recipient.id, anticipation.id).id
-      PagarMe::BulkAnticipation.delete(recipient.id, anticipation.id)
-      assert_raises PagarMe::NotFound do
-        PagarMe::BulkAnticipation.find recipient.id, anticipation.id
-      end
-
-      anticipation = recipient.bulk_anticipate anticipation_params(build: true)
-      assert_equal anticipation.id, PagarMe::BulkAnticipation.find(recipient.id, anticipation.id).id
-      anticipation.delete
-      assert_raises PagarMe::NotFound do
-        PagarMe::BulkAnticipation.find recipient.id, anticipation.id
-      end
-    end
-
     protected
     def anticipation_params(params = Hash.new)
       anticipations_limits_params(reasonable_amount).merge params


### PR DESCRIPTION
Este PR remove as chamadas para executar confirm e delete de bulk anticipiations.
Também foram removidas as referências para o parâmetro `build` em um arquivo de teste.