### PR TITLE
feat: Adds endpoint to create KYC link for recipient

### DIFF
--- a/lib/pagarme/resources/kyc.rb
+++ b/lib/pagarme/resources/kyc.rb
@@ -1,0 +1,18 @@
+module PagarMe
+  class Kyc < PagarMeObject
+    class << self
+      def parent_resource_name
+        'recipients'
+      end
+
+      def url(recipient_id)
+        ["/#{parent_resource_name}", recipient_id, "kyc_link"].join '/'
+      end
+
+      def create_link(recipient_id)
+        raise RequestError.new('Invalid ID') unless recipient_id.present?
+        PagarMe::Request.post( url(recipient_id) ).call
+      end
+    end
+  end
+end

--- a/lib/pagarme/resources/recipient.rb
+++ b/lib/pagarme/resources/recipient.rb
@@ -26,6 +26,10 @@ module PagarMe
       PagarMe::Transfer.create recipient_id: id, amount: amount
     end
 
+    def create_kyc_link()
+      PagarMe::Kyc.create_link id
+    end
+
     def self.default
       Company.default_recipient
     end


### PR DESCRIPTION
Este PR adiciona a chamada para a criação de link de KYC, conforme esta [documentação](https://docs.pagar.me/v4/reference/cria%C3%A7%C3%A3o-de-link-kyc).

Como não é possível chamar o endpoint com sucesso para chaves de teste, foi feito um mock local dos endpoints necessários. Também foi escrito localmente um teste de asserção para garantir que o retorno contém as propriedades esperadas em caso de sucesso:
![image](https://github.com/pagarme/pagarme-ruby/assets/9416565/7b83d8f6-8907-41cf-8e9c-6761ad1146f2)

Também foi feita uma chamada diretamente para a API de forma a provar que embora não haja sucesso, o endpoint está sendo chamado corretamente (já que o erro retornado é dele). O mesmo código de asserção anterior foi utilizado:
![image](https://github.com/pagarme/pagarme-ruby/assets/9416565/c4a8cc30-8f01-4bf8-84a7-76e6a361da8b)
